### PR TITLE
Add explicit dep on lit as workaround for npm file: dep issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.2",
             "license": "BSD-3-Clause",
             "dependencies": {
+                "lit": "^2.2.2",
                 "simple-carousel": "file:./build-it-with-lit/02-simple-carousel/"
             },
             "devDependencies": {
@@ -16,6 +17,7 @@
             }
         },
         "build-it-with-lit/02-simple-carousel": {
+            "name": "simple-carousel",
             "version": "0.0.1",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1753,8 +1755,7 @@
         },
         "node_modules/@lit/reactive-element": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.1.tgz",
-            "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
+            "license": "BSD-3-Clause"
         },
         "node_modules/@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
@@ -2103,8 +2104,7 @@
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-            "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+            "license": "MIT"
         },
         "node_modules/@types/ws": {
             "version": "7.4.7",
@@ -4610,9 +4610,8 @@
         },
         "node_modules/husky": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "husky": "lib/bin.js"
             },
@@ -5115,8 +5114,7 @@
         },
         "node_modules/lit": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.2.tgz",
-            "integrity": "sha512-eN3+2QRHn/erxYB88AXiiRgQA6RltE9MhzySCwX+ACOxA/MLWN3VdXvcbZD9PN09zmUwlgzDvW3T84YWj2Sa0A==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lit/reactive-element": "^1.3.0",
                 "lit-element": "^3.2.0",
@@ -5328,8 +5326,7 @@
         },
         "node_modules/lit-element": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
-            "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lit/reactive-element": "^1.3.0",
                 "lit-html": "^2.2.0"
@@ -5337,8 +5334,7 @@
         },
         "node_modules/lit-html": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.2.tgz",
-            "integrity": "sha512-cJofCRXuizwyaiGt9pJjJOcauezUlSB6t87VBXsPwRhbzF29MgD8GH6fZ0BuZdXAAC02IRONZBd//VPUuU8QbQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@types/trusted-types": "^2.0.2"
             }
@@ -8938,9 +8934,7 @@
             }
         },
         "@lit/reactive-element": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.1.tgz",
-            "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
+            "version": "1.3.1"
         },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
@@ -9266,9 +9260,7 @@
             }
         },
         "@types/trusted-types": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-            "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+            "version": "2.0.2"
         },
         "@types/ws": {
             "version": "7.4.7",
@@ -11145,8 +11137,6 @@
         },
         "husky": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true
         },
         "ignore": {
@@ -11523,8 +11513,6 @@
         },
         "lit": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.2.tgz",
-            "integrity": "sha512-eN3+2QRHn/erxYB88AXiiRgQA6RltE9MhzySCwX+ACOxA/MLWN3VdXvcbZD9PN09zmUwlgzDvW3T84YWj2Sa0A==",
             "requires": {
                 "@lit/reactive-element": "^1.3.0",
                 "lit-element": "^3.2.0",
@@ -11707,8 +11695,6 @@
         },
         "lit-element": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
-            "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
             "requires": {
                 "@lit/reactive-element": "^1.3.0",
                 "lit-html": "^2.2.0"
@@ -11716,8 +11702,6 @@
         },
         "lit-html": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.2.tgz",
-            "integrity": "sha512-cJofCRXuizwyaiGt9pJjJOcauezUlSB6t87VBXsPwRhbzF29MgD8GH6fZ0BuZdXAAC02IRONZBd//VPUuU8QbQ==",
             "requires": {
                 "@types/trusted-types": "^2.0.2"
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "prepare": "husky install"
     },
     "dependencies": {
-        "simple-carousel": "file:./build-it-with-lit/02-simple-carousel/"
+        "simple-carousel": "file:./build-it-with-lit/02-simple-carousel/",
+        "lit": "^2.2.2"
     },
     "devDependencies": {
         "husky": "^7.0.0"


### PR DESCRIPTION
Works around issue https://github.com/lit/video-series-samples/issues/6 temporarily.

NPM doesn't support installing transient dependencies through `file:` deps, so we need to explicitly declare the dependency on Lit.

Once https://github.com/npm/cli/pull/4745 is merged and supported in `npm`, we can remove this workaround.

I missed this when manually testing because the file: dep uses symlinks, causing my manual test to work. Once merged I tested through a Github install and it failed.

