### PR TITLE
Simplify the simple-carousel logic inspired by lit.dev carousel tutorial

### DIFF
--- a/build-it-with-lit/02-simple-carousel/lib/constants.js
+++ b/build-it-with-lit/02-simple-carousel/lib/constants.js
@@ -3,11 +3,11 @@
  * Copyright 2021 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import { svg } from "lit";
-export const BOOTSTRAP_CHEVRON_RIGHT = svg `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-right" viewBox="0 0 16 16">
+import { html } from "lit";
+export const BOOTSTRAP_CHEVRON_RIGHT = html `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-right" viewBox="0 0 16 16">
  <path fill-rule="evenodd" stroke="#101423" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
  </svg>`;
-export const BOOTSTRAP_CHEVRON_LEFT = svg `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-left" viewBox="0 0 16 16">
+export const BOOTSTRAP_CHEVRON_LEFT = html `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-left" viewBox="0 0 16 16">
  <path fill-rule="evenodd" stroke="#101423" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
  </svg>`;
 const SLIDE_OUT_BACK_LEFT = [

--- a/build-it-with-lit/02-simple-carousel/lib/simple-carousel.js
+++ b/build-it-with-lit/02-simple-carousel/lib/simple-carousel.js
@@ -33,7 +33,7 @@ let SimpleCarousel = class SimpleCarousel extends LitElement {
      * Return slide index in the range of [0, slideElement.length)
      */
     get wrappedIndex() {
-        return wrap(this.slideIndex, this.slideElements.length);
+        return wrapIndex(this.slideIndex, this.slideElements.length);
     }
     render() {
         const containerStyles = {
@@ -67,8 +67,11 @@ let SimpleCarousel = class SimpleCarousel extends LitElement {
         // the 'updated' lifecycle callback.
         if (changedProperties.has("slideIndex")) {
             const oldSlideIndex = changedProperties.get("slideIndex");
-            const advancing = this.slideIndex > oldSlideIndex;
-            if (advancing) {
+            if (oldSlideIndex === undefined) {
+                return;
+            }
+            const isAdvancing = this.slideIndex > oldSlideIndex;
+            if (isAdvancing) {
                 // Animate forwards
                 this.navigateWithAnimation(1, SLIDE_LEFT_OUT, SLIDE_RIGHT_IN);
             }
@@ -80,8 +83,8 @@ let SimpleCarousel = class SimpleCarousel extends LitElement {
     }
     async navigateWithAnimation(nextSlideOffset, leavingAnimation, enteringAnimation) {
         this.initializeSlides();
-        const wrappedPriorIdx = wrap(this.slideIndex - nextSlideOffset, this.slideElements.length);
-        const elLeaving = this.slideElements[wrappedPriorIdx];
+        const leavingElIndex = wrapIndex(this.slideIndex - nextSlideOffset, this.slideElements.length);
+        const elLeaving = this.slideElements[leavingElIndex];
         showSlide(elLeaving);
         // Animate out current element
         const leavingAnim = elLeaving.animate(leavingAnimation[0], leavingAnimation[1]);
@@ -170,7 +173,7 @@ function hideSlide(el) {
 function showSlide(el) {
     el.classList.remove("slide-hidden");
 }
-function wrap(idx, max) {
+function wrapIndex(idx, max) {
     return ((idx % max) + max) % max;
 }
 //# sourceMappingURL=simple-carousel.js.map

--- a/build-it-with-lit/02-simple-carousel/package.json
+++ b/build-it-with-lit/02-simple-carousel/package.json
@@ -15,7 +15,7 @@
     "format": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --ignore-path ./.eslintignore --write",
     "analyze": "cem analyze --litelement --globs \"src/**/*.ts\"",
     "analyze:watch": "cem analyze --litelement --globs \"src/**/*.ts\" --watch",
-    "serve": "wds --watch",
+    "serve": "wds --watch --open /dev/index.html",
     "serve:prod": "MODE=prod npm run serve"
   },
   "keywords": [

--- a/build-it-with-lit/02-simple-carousel/src/constants.ts
+++ b/build-it-with-lit/02-simple-carousel/src/constants.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { svg } from "lit";
+import { html } from "lit";
 
-export const BOOTSTRAP_CHEVRON_RIGHT = svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-right" viewBox="0 0 16 16">
+export const BOOTSTRAP_CHEVRON_RIGHT = html`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-right" viewBox="0 0 16 16">
  <path fill-rule="evenodd" stroke="#101423" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
  </svg>`;
-export const BOOTSTRAP_CHEVRON_LEFT = svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-left" viewBox="0 0 16 16">
+export const BOOTSTRAP_CHEVRON_LEFT = html`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#101423" class="bi bi-chevron-left" viewBox="0 0 16 16">
  <path fill-rule="evenodd" stroke="#101423" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
  </svg>`;
 

--- a/build-it-with-lit/02-simple-carousel/src/simple-carousel.ts
+++ b/build-it-with-lit/02-simple-carousel/src/simple-carousel.ts
@@ -70,7 +70,7 @@ export class SimpleCarousel extends LitElement {
    * Return slide index in the range of [0, slideElement.length)
    */
   get wrappedIndex(): number {
-    return wrap(this.slideIndex, this.slideElements.length);
+    return wrapIndex(this.slideIndex, this.slideElements.length);
   }
 
   override render() {
@@ -108,9 +108,12 @@ export class SimpleCarousel extends LitElement {
     // the 'updated' lifecycle callback.
     if (changedProperties.has("slideIndex")) {
       const oldSlideIndex = changedProperties.get("slideIndex");
-      const advancing = this.slideIndex > oldSlideIndex;
+      if (oldSlideIndex === undefined) {
+        return;
+      }
+      const isAdvancing = this.slideIndex > oldSlideIndex;
 
-      if (advancing) {
+      if (isAdvancing) {
         // Animate forwards
         this.navigateWithAnimation(1, SLIDE_LEFT_OUT, SLIDE_RIGHT_IN);
       } else {
@@ -136,11 +139,11 @@ export class SimpleCarousel extends LitElement {
     enteringAnimation: AnimationTuple
   ) {
     this.initializeSlides();
-    const wrappedPriorIdx = wrap(
+    const leavingElIndex = wrapIndex(
       this.slideIndex - nextSlideOffset,
       this.slideElements.length
     );
-    const elLeaving = this.slideElements[wrappedPriorIdx];
+    const elLeaving = this.slideElements[leavingElIndex];
     showSlide(elLeaving);
 
     // Animate out current element
@@ -197,7 +200,7 @@ function showSlide(el: HTMLElement) {
   el.classList.remove("slide-hidden");
 }
 
-function wrap(idx: number, max: number): number {
+function wrapIndex(idx: number, max: number): number {
   return ((idx % max) + max) % max;
 }
 


### PR DESCRIPTION
### Context

The simple-carousel made in the video breaks the attribute/property binding such that attribute changes do not move the carousel. This was fixed by adding some very complicated wrapping logic (inspired by a legacy carousel example Steve had made).

This PR is inspired by Steve's carousel lit.dev tutorial and the **much simpler** logic for advancing a carousel slide.

### How

We build off the first video's concept where `this.slideIndex` can be an unbounded integer [-Inf, +Inf]. We add a `wrappedIndex` getter which returns a clamped index within the bounds of slide elements.

Now the math is extremely simple for calculating whether to animate left or right. We check if the old index is less than or larger than the current index, and animate accordingly.

This maintains the behavior built in the video, while also adding the attribute driving the animation with less complexity.

### Testing

This was tested manually. See screen recording.

Tested:
  - Clicking back and forth on the buttons (and wrapping).
  - Clicking fast.
  - Setting the `slideindex` attribute (greater than and less than current slide index).

Test by pulling this branch. Running `npm run build:watch` and `npm run serve`, and opening http://localhost:8000/dev/index.html

https://user-images.githubusercontent.com/15080861/165393659-d786fae2-1a26-44de-a414-48d59168655e.mov


