### PR TITLE
Hide simple-carousel when it's not defined

### DIFF
--- a/build-it-with-lit/02-simple-carousel/dev/index.html
+++ b/build-it-with-lit/02-simple-carousel/dev/index.html
@@ -34,6 +34,14 @@
         width: 100%;
         height: auto;
       }
+
+      /*
+      Hide the simple-carousel element until it is defined, preventing a flash
+      of unstyled content.
+      */
+      simple-carousel:not(:defined) > * {
+        display: none;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
This is a small quality of life improvement to the simple-carousel demo. Hiding the flash of light dom before the component is defined.

Tested manually by refreshing page.