### PR TITLE
Update simple-carousel Youtube link to point at the new video location

### DIFF
--- a/build-it-with-lit/02-simple-carousel/README.md
+++ b/build-it-with-lit/02-simple-carousel/README.md
@@ -1,10 +1,10 @@
 [![Build it with Lit simple carousel Youtube
-thumbnail](http://img.youtube.com/vi/N3DetHTpQgc/maxresdefault.jpg)](https://www.youtube.com/watch?v=N3DetHTpQgc)
+thumbnail](http://img.youtube.com/vi/2RftvylEtrE/maxresdefault.jpg)](https://www.youtube.com/watch?v=2RftvylEtrE)
 
 # Simple Carousel
 
 This is the completed simple-carousel Lit component that accompanies the [second
-Build It With Lit video](https://www.youtube.com/watch?v=N3DetHTpQgc).
+Build It With Lit video](https://www.youtube.com/watch?v=2RftvylEtrE).
 
 Install directly from Github:
 


### PR DESCRIPTION
The video was re-uploaded to Youtube and the link changed.

This PR updates the link to point at the new location. Clicking this link should take you to the unlisted video (which is scheduled to release tomorrow at 9am PT).

Thank you!